### PR TITLE
[do not merge] Experiments with virtual-list

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lit-html": "^0.8.0",
     "pwa-helpers": "PolymerLabs/pwa-helpers",
     "redux-thunk": "^2.2.0",
-    "reselect": "^3.0.1"
+    "reselect": "^3.0.1",
+    "virtual-list": "github:PolymerLabs/virtual-list#master"
   }
 }

--- a/src/components/hn-item.js
+++ b/src/components/hn-item.js
@@ -10,6 +10,7 @@
 
 import { LitElement, html } from '../../node_modules/@polymer/lit-element/lit-element.js';
 import { verticalList } from '../../node_modules/virtual-list/lit-html/lit-list.js';
+import Layout from '../../node_modules/virtual-list/layouts/layout-1d.js';
 import { unsafeHTML } from '../../node_modules/lit-html/lib/unsafe-html.js';
 import { connect } from '../../node_modules/pwa-helpers/connect-mixin.js';
 import { fetchItem, fetchItemIfNeeded } from '../actions/items.js';
@@ -28,6 +29,12 @@ store.addReducers({
 });
 
 store.dispatch(loadFavorites());
+
+const layout = new Layout({
+  itemSize: {
+    y: 2000
+  }
+});
 
 export class HnItemElement extends connect(store)(LitElement) {
   render({ favorites, item }) {
@@ -52,7 +59,7 @@ export class HnItemElement extends connect(store)(LitElement) {
       <div hidden="${!item.content}">${unsafeHTML(item.content)}</div>
       ${verticalList(comments, (comment) => html`
         <hn-comment id="${comment.id}" comment="${comment}" itemId="${item.id}"></hn-comment>
-      `)}
+      `, layout)}
     </div>
     ${item.failure ? html`<p>Item not found</p>` : ''}
     `;

--- a/src/components/hn-item.js
+++ b/src/components/hn-item.js
@@ -9,7 +9,7 @@
  */
 
 import { LitElement, html } from '../../node_modules/@polymer/lit-element/lit-element.js';
-import { repeat } from '../../node_modules/lit-html/lib/repeat.js';
+import { verticalList } from '../../node_modules/virtual-list/lit-html/lit-list.js';
 import { unsafeHTML } from '../../node_modules/lit-html/lib/unsafe-html.js';
 import { connect } from '../../node_modules/pwa-helpers/connect-mixin.js';
 import { fetchItem, fetchItemIfNeeded } from '../actions/items.js';
@@ -50,7 +50,7 @@ export class HnItemElement extends connect(store)(LitElement) {
           isFavorite="${favorites && item && favorites[item.id]}">
       </hn-summary>
       <div hidden="${!item.content}">${unsafeHTML(item.content)}</div>
-      ${repeat(comments, (comment) => html`
+      ${verticalList(comments, (comment) => html`
         <hn-comment id="${comment.id}" comment="${comment}" itemId="${item.id}"></hn-comment>
       `)}
     </div>

--- a/src/components/hn-list.js
+++ b/src/components/hn-list.js
@@ -9,7 +9,7 @@
  */
 
 import { LitElement, html } from '../../node_modules/@polymer/lit-element/lit-element.js';
-import { repeat } from '../../node_modules/lit-html/lib/repeat.js';
+import { verticalList } from '../../node_modules/virtual-list/lit-html/lit-list.js';
 import { connect } from '../../node_modules/pwa-helpers/connect-mixin.js';
 import { fetchList, fetchListIfNeeded } from '../actions/lists.js';
 import { loadFavorites } from '../actions/favorites.js';
@@ -41,6 +41,14 @@ export class HnListElement extends connect(store)(LitElement) {
         margin: 0 8px 8px 0;
       }
     </style>
+    <div>
+    ${verticalList(items, (item) => html`
+      <hn-summary
+          item="${item}"
+          isFavorite="${favorites && item && favorites[item.id]}">
+      </hn-summary>
+    `)}
+    </div>
     ${
       list.id !== 'favorites' ?
       html`
@@ -51,12 +59,6 @@ export class HnListElement extends connect(store)(LitElement) {
       ` :
       null
     }
-    ${repeat(items, (item) => html`
-      <hn-summary
-          item="${item}"
-          isFavorite="${favorites && item && favorites[item.id]}">
-      </hn-summary>
-    `)}
     ${
       list.id !== 'favorites' && items.length ?
       html`


### PR DESCRIPTION
Experimenting with https://github.com/PolymerLabs/virtual-list

Use `virtualList` instead of `repeat` to render only the viewable rows. 

Rendering speed of comments (e.g. http://localhost:8081/item?id=16679354) decreases of ~100ms:

with `repeat` (master):
![screen shot 2018-03-26 at 11 27 15 am](https://user-images.githubusercontent.com/6173664/37925184-d049a542-30e8-11e8-8826-ac29501591d6.png)

with `virtualList`:
![screen shot 2018-03-26 at 11 24 06 am](https://user-images.githubusercontent.com/6173664/37925161-c1f58ee8-30e8-11e8-8952-574710fad4fd.png)